### PR TITLE
Compatibility with Plugin API changes in rabbitmq-server:bug24926

### DIFF
--- a/src/rabbit_lvc_plugin.erl
+++ b/src/rabbit_lvc_plugin.erl
@@ -8,6 +8,7 @@
                    [{description, "last-value cache exchange type"},
                     {mfa, {rabbit_lvc_plugin, setup_schema, []}},
                     {mfa, {rabbit_registry, register, [exchange, <<"x-lvc">>, rabbit_exchange_type_lvc]}},
+                    {cleanup, {rabbit_registry, unregister, [exchange, <<"x-lvc">>]}},
                     {requires, rabbit_registry},
                     {enables, recovery}]}).
 


### PR DESCRIPTION
In this patch I've only reversed the registration of the x-recent-history exchange in rabbit_registry. I have not written a "cleanup action" to remove the mnesia tables, but if you think that would make sense (when the plugin is disabled at runtime) then I will do so and update the PR.
